### PR TITLE
Add CLI integration tests, template sync CI, and README updates

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,6 +28,30 @@ jobs:
       - name: Run template validation
         run: python scripts/validate_templates.py
 
+  cli-tests:
+    name: CLI tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install CLI package
+        run: pip install ./cli[dev]
+
+      - name: Verify entry point
+        run: bootstrap-iac --version
+
+      - name: Run tests
+        run: pytest cli/tests/ -q
+
   markdown-lint:
     name: Markdown lint
     runs-on: ubuntu-latest

--- a/cli/README.md
+++ b/cli/README.md
@@ -73,7 +73,7 @@ Exits with code `0` if no placeholders remain, `1` otherwise.
 | `--company NAME` | | Company / organisation name |
 | `--cloud PROVIDER` | | Primary cloud: `azure` \| `aws` \| `gcp` |
 | `--module-prefix PREFIX` | | Module directory prefix (e.g. `tf-module`) |
-| `--orchestration TOOL` | | `terragrunt` \| `terramate` \| `none` |
+| `--orchestration TOOL` | | `terragrunt` \| `terramate` \| `pulumi` \| `none` |
 | `--orchestration-dir DIR` | | Directory containing orchestration configs |
 | `--ci-cd PLATFORM` | | `github-actions` \| `azure-devops` \| `gitlab-ci` \| `atlantis` |
 | `--auth PATTERN` | | Authentication pattern description |
@@ -124,9 +124,9 @@ Exits with code `0` if no placeholders remain, `1` otherwise.
 
 | Cloud | Orchestration | CI/CD |
 |-------|--------------|-------|
-| Azure | Terragrunt, Terramate, None | GitHub Actions, Azure DevOps, GitLab CI, Atlantis |
-| AWS | Terragrunt, Terramate, None | GitHub Actions, Azure DevOps, GitLab CI, Atlantis |
-| GCP | Terragrunt, Terramate, None | GitHub Actions, Azure DevOps, GitLab CI, Atlantis |
+| Azure | Terragrunt, Terramate, Pulumi, None | GitHub Actions, Azure DevOps, GitLab CI, Atlantis |
+| AWS | Terragrunt, Terramate, Pulumi, None | GitHub Actions, Azure DevOps, GitLab CI, Atlantis |
+| GCP | Terragrunt, Terramate, Pulumi, None | GitHub Actions, Azure DevOps, GitLab CI, Atlantis |
 
 ## Development
 

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1,0 +1,344 @@
+"""Integration tests for the bootstrap-iac CLI entry point."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bootstrap_iac import __version__
+from bootstrap_iac.cli import main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+runner = CliRunner()
+
+
+def _make_workspace(tmp_path: Path) -> Path:
+    """Create a minimal workspace with a provider block."""
+    (tmp_path / "main.tf").write_text('provider "azurerm" {\n  features {}\n}\n')
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# --help / --version
+# ---------------------------------------------------------------------------
+
+
+def test_help_flag():
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "bootstrap-iac" in result.output.lower() or "Bootstrap" in result.output
+
+
+def test_version_flag():
+    result = runner.invoke(main, ["-V"])
+    assert result.exit_code == 0
+    assert __version__ in result.output
+
+
+# ---------------------------------------------------------------------------
+# --validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_clean_directory(tmp_path):
+    (tmp_path / "README.md").write_text("Hello, no placeholders here.\n")
+    result = runner.invoke(main, ["--validate", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "No unreplaced placeholders" in result.output
+
+
+def test_validate_dirty_directory(tmp_path):
+    (tmp_path / "copilot-instructions.md").write_text(
+        "Company: {{COMPANY_NAME}}\n"
+    )
+    result = runner.invoke(main, ["--validate", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "COMPANY_NAME" in result.output
+
+
+def test_validate_single_file(tmp_path):
+    f = tmp_path / "test.md"
+    f.write_text("Provider: {{CLOUD_PROVIDER}}\n")
+    result = runner.invoke(main, ["--validate", str(f)])
+    assert result.exit_code == 1
+    assert "CLOUD_PROVIDER" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --dry-run + --non-interactive
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_non_interactive(tmp_path):
+    ws = _make_workspace(tmp_path)
+    result = runner.invoke(
+        main,
+        [
+            "--workspace", str(ws),
+            "--company", "TestCo",
+            "--cloud", "azure",
+            "--non-interactive",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Dry run" in result.output or "dry run" in result.output.lower()
+    assert "Would generate" in result.output
+    # No files should be written
+    assert not (ws / ".github").exists()
+    assert not (ws / "CLAUDE.md").exists()
+
+
+def test_dry_run_copilot_target(tmp_path):
+    ws = _make_workspace(tmp_path)
+    result = runner.invoke(
+        main,
+        [
+            "--workspace", str(ws),
+            "--company", "TestCo",
+            "--cloud", "azure",
+            "--target", "copilot",
+            "--non-interactive",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Would generate" in result.output
+    # Should list copilot files but not claude
+    assert "copilot-instructions.md" in result.output
+    assert "CLAUDE.md" not in result.output
+
+
+def test_dry_run_claude_target(tmp_path):
+    ws = _make_workspace(tmp_path)
+    result = runner.invoke(
+        main,
+        [
+            "--workspace", str(ws),
+            "--company", "TestCo",
+            "--cloud", "azure",
+            "--target", "claude",
+            "--non-interactive",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Would generate" in result.output
+    assert "CLAUDE.md" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Full generation (non-interactive)
+# ---------------------------------------------------------------------------
+
+
+def test_generate_writes_files(tmp_path):
+    ws = _make_workspace(tmp_path)
+    result = runner.invoke(
+        main,
+        [
+            "--workspace", str(ws),
+            "--company", "Acme",
+            "--cloud", "azure",
+            "--non-interactive",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Bootstrap complete" in result.output
+
+    # Copilot files
+    assert (ws / ".github" / "copilot-instructions.md").exists()
+    instructions = (ws / ".github" / "copilot-instructions.md").read_text()
+    assert "Acme" in instructions
+
+    # Claude files
+    assert (ws / "CLAUDE.md").exists()
+    claude = (ws / "CLAUDE.md").read_text()
+    assert "Acme" in claude
+
+
+def test_generate_skips_existing(tmp_path):
+    ws = _make_workspace(tmp_path)
+    # Pre-create a copilot instructions file
+    gh_dir = ws / ".github"
+    gh_dir.mkdir()
+    existing = gh_dir / "copilot-instructions.md"
+    existing.write_text("original content")
+
+    result = runner.invoke(
+        main,
+        [
+            "--workspace", str(ws),
+            "--company", "Acme",
+            "--cloud", "azure",
+            "--non-interactive",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Skipped" in result.output
+    # File should remain unchanged
+    assert existing.read_text() == "original content"
+
+
+def test_generate_overwrite(tmp_path):
+    ws = _make_workspace(tmp_path)
+    gh_dir = ws / ".github"
+    gh_dir.mkdir()
+    existing = gh_dir / "copilot-instructions.md"
+    existing.write_text("original content")
+
+    result = runner.invoke(
+        main,
+        [
+            "--workspace", str(ws),
+            "--company", "Acme",
+            "--cloud", "azure",
+            "--non-interactive",
+            "--overwrite",
+        ],
+    )
+    assert result.exit_code == 0
+    # File should be overwritten with generated content
+    assert existing.read_text() != "original content"
+    assert "Acme" in existing.read_text()
+
+
+def test_generate_output_dir(tmp_path):
+    ws = _make_workspace(tmp_path)
+    out = tmp_path / "output"
+    out.mkdir()
+
+    result = runner.invoke(
+        main,
+        [
+            "--workspace", str(ws),
+            "--output-dir", str(out),
+            "--company", "Acme",
+            "--cloud", "azure",
+            "--non-interactive",
+        ],
+    )
+    assert result.exit_code == 0
+    assert (out / ".github" / "copilot-instructions.md").exists()
+    assert (out / "CLAUDE.md").exists()
+    # Original workspace should NOT have generated files
+    assert not (ws / "CLAUDE.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Cloud and orchestration flag variations
+# ---------------------------------------------------------------------------
+
+
+def test_generate_aws(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    result = runner.invoke(
+        main,
+        [
+            "--workspace", str(ws),
+            "--company", "TestCo",
+            "--cloud", "aws",
+            "--non-interactive",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Would generate" in result.output
+
+
+def test_generate_gcp(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    result = runner.invoke(
+        main,
+        [
+            "--workspace", str(ws),
+            "--company", "TestCo",
+            "--cloud", "gcp",
+            "--non-interactive",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Would generate" in result.output
+
+
+def test_generate_with_orchestration(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    result = runner.invoke(
+        main,
+        [
+            "--workspace", str(ws),
+            "--company", "TestCo",
+            "--cloud", "azure",
+            "--orchestration", "terragrunt",
+            "--orchestration-dir", "infra",
+            "--non-interactive",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Would generate" in result.output
+
+
+def test_generate_with_pulumi(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    result = runner.invoke(
+        main,
+        [
+            "--workspace", str(ws),
+            "--company", "TestCo",
+            "--cloud", "azure",
+            "--orchestration", "pulumi",
+            "--non-interactive",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Would generate" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Discovery integration
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_detects_cloud(tmp_path):
+    ws = _make_workspace(tmp_path)
+    result = runner.invoke(
+        main,
+        [
+            "--workspace", str(ws),
+            "--company", "TestCo",
+            "--non-interactive",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "cloud=Azure" in result.output
+
+
+def test_discovery_detects_github_actions(tmp_path):
+    ws = _make_workspace(tmp_path)
+    (ws / ".github" / "workflows").mkdir(parents=True)
+    (ws / ".github" / "workflows" / "ci.yml").write_text("name: CI\n")
+    result = runner.invoke(
+        main,
+        [
+            "--workspace", str(ws),
+            "--company", "TestCo",
+            "--non-interactive",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "ci_cd=GitHub Actions" in result.output

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import textwrap
 from pathlib import Path
 
 from click.testing import CliRunner

--- a/scripts/validate_templates.py
+++ b/scripts/validate_templates.py
@@ -6,6 +6,7 @@ Checks:
   2. Agent and instruction .tmpl files: YAML frontmatter is present and valid.
   3. Example files: no remaining {{...}} tokens.
   4. Templates referenced in SKILL.md all exist on disk.
+  5. references/ and cli/bootstrap_iac/templates/ contain identical .tmpl files.
 """
 
 import re

--- a/scripts/validate_templates.py
+++ b/scripts/validate_templates.py
@@ -190,6 +190,42 @@ def check_skill_md_template_references() -> list[str]:
     return errors
 
 
+TEMPLATES_DIR = REPO_ROOT / "cli" / "bootstrap_iac" / "templates"
+
+
+def check_template_sync() -> list[str]:
+    """Verify that references/ and cli/bootstrap_iac/templates/ are in sync."""
+    errors: list[str] = []
+
+    ref_templates = {
+        str(p.relative_to(REFERENCES_DIR))
+        for p in REFERENCES_DIR.rglob("*.tmpl")
+    }
+    cli_templates = {
+        str(p.relative_to(TEMPLATES_DIR))
+        for p in TEMPLATES_DIR.rglob("*.tmpl")
+    }
+
+    only_in_references = sorted(ref_templates - cli_templates)
+    only_in_cli = sorted(cli_templates - ref_templates)
+
+    for f in only_in_references:
+        errors.append(f"references/{f} exists but cli/bootstrap_iac/templates/{f} is missing")
+    for f in only_in_cli:
+        errors.append(f"cli/bootstrap_iac/templates/{f} exists but references/{f} is missing")
+
+    # Check content matches for files present in both locations
+    for rel in sorted(ref_templates & cli_templates):
+        ref_content = (REFERENCES_DIR / rel).read_text(encoding="utf-8")
+        cli_content = (TEMPLATES_DIR / rel).read_text(encoding="utf-8")
+        if ref_content != cli_content:
+            errors.append(
+                f"{rel}: content differs between references/ and cli/bootstrap_iac/templates/"
+            )
+
+    return errors
+
+
 def main() -> int:
     all_errors: list[tuple[str, list[str]]] = []
 
@@ -198,6 +234,7 @@ def main() -> int:
         ("YAML frontmatter in agent/instruction templates", check_yaml_frontmatter),
         ("No remaining placeholders in example files", check_examples_no_placeholders),
         ("Template files referenced in SKILL.md exist", check_skill_md_template_references),
+        ("references/ and cli/templates/ in sync", check_template_sync),
     ]
 
     for label, fn in checks:


### PR DESCRIPTION
## Summary

Closes #5 — quality-of-life improvements for the bootstrap CLI.

### Changes

1. **CLI integration tests** (`cli/tests/test_cli.py`) — 18 end-to-end tests using Click's CliRunner covering:
   - `--help`, `--version`
   - `--validate` (clean, dirty, single-file)
   - `--dry-run` + `--non-interactive`
   - `--target copilot/claude/both`
   - Full generation (write files, skip existing, overwrite, output-dir)
   - Cloud variations (azure/aws/gcp)
   - Orchestration variations (terragrunt/pulumi)
   - Discovery integration (cloud detection, CI/CD detection)

2. **Template sync CI check** — new `check_template_sync()` in `scripts/validate_templates.py` verifies `references/` and `cli/bootstrap_iac/templates/` have identical `.tmpl` files and content.

3. **CLI test CI job** — new `cli-tests` job in `validate.yml` that installs the package via pip, verifies the entr3. **CLI(`boots3. **CLI test CI job** — new `cli-tests` job in `validate.yml` that inmi3. **CLI test CI jopti3. **CLI test CI job** — new `cli-tests` job in `validate.ysts passing (93 existing + 18 new).