### PR TITLE
docs: update CI pipeline description and example tree to match repo

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,9 +64,9 @@ When reviewing generated Copilot customization files:
 ## CI Pipeline
 
 The GitHub Actions workflow (`.github/workflows/validate.yml`) runs:
-1. **Template validation** (`scripts/validate_templates.py`) — 4 checks: placeholder syntax, YAML frontmatter, example cleanliness, SKILL.md references.
-2. **Markdown lint** — only on `README.md`, `SKILL.md`, `CLAUDE.md`.
-3. **CodeQL** — default security scanning.
+1. **Template validation** (`scripts/validate_templates.py`) — 5 checks: placeholder syntax, YAML frontmatter, example cleanliness, SKILL.md references, and references/cli template sync.
+2. **CLI tests** — installs the CLI package, verifies the entry point, and runs `pytest cli/tests/`.
+3. **Markdown lint** — only on `README.md`, `SKILL.md`, `CLAUDE.md`.
 
 ## Review Guidelines
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ This repo is a **meta-tool**: it generates AI agent customization files (for VS 
 | `references/` | **Read-only** `.tmpl` template files with `{{PLACEHOLDER}}` syntax. Never modify these. |
 | `cli/bootstrap_iac/` | Python CLI package: `cli.py` (Click entrypoint), `interview.py` (context builder), `generator.py` (template engine), `discovery.py` (workspace scanner), `validator.py` (output checker). |
 | `cli/bootstrap_iac/templates/` | Bundled copy of templates shipped with the CLI package. Must stay in sync with `references/`. |
-| `scripts/validate_templates.py` | CI validator: checks placeholder syntax, YAML frontmatter, example cleanliness, and SKILL.md references. |
+| `scripts/validate_templates.py` | CI validator: checks placeholder syntax, YAML frontmatter, example cleanliness, SKILL.md references, and references/cli template sync. |
 | `examples/` | Fully-resolved example outputs (no `{{PLACEHOLDER}}` tokens should remain). |
 
 ## Key Conventions

--- a/README.md
+++ b/README.md
@@ -176,28 +176,42 @@ cp ~/git/iac-bootstrap/.claude/commands/bootstrap.md .claude/commands/
 │           └── create-infra-pipeline.md.tmpl
 │
 └── examples/
-    └── azure-terragrunt/                 # Complete example for Azure + Terragrunt
-        ├── .github/                      # Copilot output
-        │   ├── copilot-instructions.md
-        │   ├── agents/
-        │   │   ├── infra-architect.agent.md
-        │   │   ├── terraform-module-builder.agent.md
-        │   │   ├── terraform-test-writer.agent.md
-        │   │   └── terragrunt-stack-manager.agent.md
-        │   ├── skills/
-        │   │   ├── create-terraform-module/SKILL.md
-        │   │   ├── create-terragrunt-stack/SKILL.md
-        │   │   └── create-infra-pipeline/SKILL.md
-        │   └── instructions/
-        │       ├── terraform-modules.instructions.md
-        │       ├── terraform-tests.instructions.md
-        │       ├── terragrunt-configs.instructions.md
-        │       └── pipeline-templates.instructions.md
-        ├── CLAUDE.md                     # Claude Code output
-        └── .claude/commands/
-            ├── create-terraform-module.md
-            ├── create-terragrunt-stack.md
-            └── create-infra-pipeline.md
+    ├── azure-terragrunt/                 # Complete example for Azure + Terragrunt
+    │   ├── .github/                      # Copilot output
+    │   │   ├── copilot-instructions.md
+    │   │   ├── agents/
+    │   │   │   ├── infra-architect.agent.md
+    │   │   │   ├── orchestration-coordinator.agent.md
+    │   │   │   ├── terraform-module-builder.agent.md
+    │   │   │   ├── terraform-test-writer.agent.md
+    │   │   │   └── terragrunt-stack-manager.agent.md
+    │   │   ├── skills/
+    │   │   │   ├── create-terraform-module/SKILL.md
+    │   │   │   ├── create-terragrunt-stack/SKILL.md
+    │   │   │   └── create-infra-pipeline/SKILL.md
+    │   │   └── instructions/
+    │   │       ├── checkov.instructions.md
+    │   │       ├── opa.instructions.md
+    │   │       ├── pipeline-templates.instructions.md
+    │   │       ├── terraform-modules.instructions.md
+    │   │       ├── terraform-tests.instructions.md
+    │   │       ├── terragrunt-configs.instructions.md
+    │   │       ├── terratest.instructions.md
+    │   │       └── tflint.instructions.md
+    │   ├── maturity-report.md            # IaC maturity assessment
+    │   ├── CLAUDE.md                     # Claude Code output
+    │   └── .claude/commands/
+    │       ├── coordinate-module-rollout.md
+    │       ├── create-terraform-module.md
+    │       ├── create-terragrunt-stack.md
+    │       └── create-infra-pipeline.md
+    ├── aws-github-actions/               # AWS + GitHub Actions (Claude only)
+    ├── aws-terraform/                    # AWS + plain Terraform
+    ├── azure-pulumi/                     # Azure + Pulumi
+    ├── azure-terramate/                  # Azure + Terramate
+    ├── gcp-github-actions/               # GCP + GitHub Actions
+    ├── github-actions-terragrunt/        # GitHub Actions + Terragrunt
+    └── gitlab-ci-terragrunt/             # GitLab CI + Terragrunt
 ```
 
 ## Cloud-Specific Templates


### PR DESCRIPTION
## Summary

Documentation had drifted from the actual repo state. This PR brings it back in sync.

### Changes

**`.github/copilot-instructions.md`** — CI Pipeline section:
- "4 checks" → "5 checks" (added template sync check)
- Added `cli-tests` job description (install package, verify entry point, run pytest)
- Removed non-existent CodeQL reference

**`README.md`** — Repository Structure / examples tree:
- Added `orchestration-coordinator.agent.md` to agents
- Added `checkov`, `opa`, `terratest`, `tflint` instruction files
- Added `maturity-report.md` to example root
- Added `coordinate-module-rollout.md` to Claude commands
- Listed all 8 example directories (was only showing `azure-terragrunt/`)