### PR TITLE
feat: config file support for deterministic re-generation

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -157,6 +157,11 @@ auth: workload-identity
 state_backend: azurerm
 naming: "{prefix}-{resource_abbreviation}-{suffix}"
 tag_strategy: merge(var.env_default_tags, var.tags)
+standard_variables: |
+  - `prefix` — Resource name prefix
+  - `location` — Azure region
+  - `resource_group_name` — Target resource group
+  - `tags` — Resource-specific tags (map(string))
 org: acme
 target: both
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -85,7 +85,7 @@ Exits with code `0` if no placeholders remain, `1` otherwise.
 | `--workspace PATH` | | IaC workspace to scan (default: `.`) |
 | `--output-dir PATH` | | Where to write files (default: `--workspace`) |
 | `--dry-run` | | Preview without writing |
-| `--overwrite` | | Overwrite existing files (default: skip) |
+| `--overwrite` | | Overwrite existing files and config (default: skip) |
 | `--non-interactive` | | Never prompt — use defaults + flags only |
 | `--validate PATH` | | Check for unreplaced placeholders |
 | `--config PATH` | | Path to `.bootstrap-iac.yaml` config file (auto-detected if omitted) |

--- a/cli/README.md
+++ b/cli/README.md
@@ -148,14 +148,14 @@ for deterministic re-generation without re-answering prompts:
 
 ```yaml
 company: Acme Corp
-cloud: azure
+cloud: Azure
 module_prefix: tf-module
-orchestration: terragrunt
+orchestration: Terragrunt
 orchestration_dir: infrastructure-config
-ci_cd: github-actions
+ci_cd: GitHub Actions
 auth: workload-identity
 state_backend: azurerm
-naming: "${var.prefix}-${var.resource_type}-${local.suffix}"
+naming: "{prefix}-{resource_abbreviation}-{suffix}"
 tag_strategy: merge(var.env_default_tags, var.tags)
 org: acme
 target: both

--- a/cli/README.md
+++ b/cli/README.md
@@ -88,6 +88,8 @@ Exits with code `0` if no placeholders remain, `1` otherwise.
 | `--overwrite` | | Overwrite existing files (default: skip) |
 | `--non-interactive` | | Never prompt — use defaults + flags only |
 | `--validate PATH` | | Check for unreplaced placeholders |
+| `--config PATH` | | Path to `.bootstrap-iac.yaml` config file (auto-detected if omitted) |
+| `--save-config` | | Write interview answers to `.bootstrap-iac.yaml` after generation |
 | `--version` | `-V` | Show version and exit |
 | `--help` | `-h` | Show help and exit |
 
@@ -138,6 +140,34 @@ pip install -e "./cli[dev]"
 cd cli
 pytest
 ```
+
+## Config File
+
+Commit a `.bootstrap-iac.yaml` (or `.bootstrap-iac.yml`) in your workspace root
+for deterministic re-generation without re-answering prompts:
+
+```yaml
+company: Acme Corp
+cloud: azure
+module_prefix: tf-module
+orchestration: terragrunt
+orchestration_dir: infrastructure-config
+ci_cd: github-actions
+auth: workload-identity
+state_backend: azurerm
+naming: "${var.prefix}-${var.resource_type}-${local.suffix}"
+tag_strategy: merge(var.env_default_tags, var.tags)
+org: acme
+target: both
+```
+
+**Behaviour:**
+
+- Auto-detected in the workspace root (or specify with `--config path`)
+- Config values serve as defaults — CLI flags override them
+- Interactive prompts skip values already provided by config
+- `bootstrap-iac --non-interactive` with a config file requires zero flags
+- Generate a config from your answers: `bootstrap-iac --save-config`
 
 ## Environment Variables
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -89,7 +89,7 @@ Exits with code `0` if no placeholders remain, `1` otherwise.
 | `--non-interactive` | | Never prompt — use defaults + flags only |
 | `--validate PATH` | | Check for unreplaced placeholders |
 | `--config PATH` | | Path to `.bootstrap-iac.yaml` config file (auto-detected if omitted) |
-| `--save-config` | | Write interview answers to `.bootstrap-iac.yaml` after generation |
+| `--save-config` | | Write interview answers after generation (to `--config` path or workspace) |
 | `--version` | `-V` | Show version and exit |
 | `--help` | `-h` | Show help and exit |
 

--- a/cli/bootstrap_iac/cli.py
+++ b/cli/bootstrap_iac/cli.py
@@ -26,7 +26,14 @@ import click
 import yaml
 
 from bootstrap_iac import __version__
-from bootstrap_iac.config import find_config, load_config, write_config
+from bootstrap_iac.config import (
+    _CICD_MAP,
+    _CLOUD_MAP,
+    _ORCH_MAP,
+    find_config,
+    load_config,
+    write_config,
+)
 from bootstrap_iac.discovery import scan_workspace
 from bootstrap_iac.generator import generate_files, get_templates_dir
 from bootstrap_iac.interview import build_context, run_interview
@@ -84,13 +91,10 @@ def _print_validation_results(issues: dict) -> int:
 # CLI definition
 # ---------------------------------------------------------------------------
 
-_CLOUD_CHOICES = click.Choice(["azure", "aws", "gcp"], case_sensitive=False)
+_CLOUD_CHOICES = click.Choice(list(_CLOUD_MAP), case_sensitive=False)
 _TARGET_CHOICES = click.Choice(["copilot", "claude", "both"], case_sensitive=False)
-_ORCH_CHOICES = click.Choice(["terragrunt", "terramate", "pulumi", "none"], case_sensitive=False)
-_CICD_CHOICES = click.Choice(
-    ["github-actions", "azure-devops", "gitlab-ci", "atlantis"],
-    case_sensitive=False,
-)
+_ORCH_CHOICES = click.Choice(list(_ORCH_MAP), case_sensitive=False)
+_CICD_CHOICES = click.Choice(list(_CICD_MAP), case_sensitive=False)
 
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
@@ -269,6 +273,9 @@ def main(
         except (yaml.YAMLError, ValueError) as exc:
             click.secho(f"  ✗  Invalid config file: {exc}", fg="red")
             sys.exit(1)
+        except OSError as exc:
+            click.secho(f"  ✗  Unable to read config file: {exc}", fg="red")
+            sys.exit(1)
 
     # ------------------------------------------------------------------ #
     # Phase 1: Discovery                                                   #
@@ -382,12 +389,19 @@ def main(
     _print_generated(results, dry_run)
 
     # ------------------------------------------------------------------ #
-    # --save-config: write answers to .bootstrap-iac.yaml                   #
+    # --save-config: write answers to config file                          #
     # ------------------------------------------------------------------ #
     if save_config and not dry_run:
-        config_out = ws_path / ".bootstrap-iac.yaml"
-        write_config(answers, config_out)
-        click.echo(f"  Saved config: {config_out}")
+        config_out = cfg_file if cfg_file else (ws_path / ".bootstrap-iac.yaml")
+        if config_out.exists() and not overwrite:
+            click.secho(
+                f"  ✗  Refusing to overwrite existing config: {config_out}. "
+                "Re-run with --overwrite to replace it.",
+                fg="red",
+            )
+        else:
+            write_config(answers, config_out)
+            click.echo(f"  Saved config: {config_out}")
 
     # ------------------------------------------------------------------ #
     # Summary                                                               #

--- a/cli/bootstrap_iac/cli.py
+++ b/cli/bootstrap_iac/cli.py
@@ -25,6 +25,7 @@ from typing import Optional
 import click
 
 from bootstrap_iac import __version__
+from bootstrap_iac.config import find_config, load_config, save_config as write_config
 from bootstrap_iac.discovery import scan_workspace
 from bootstrap_iac.generator import generate_files, get_templates_dir
 from bootstrap_iac.interview import build_context, run_interview
@@ -181,6 +182,22 @@ _CICD_CHOICES = click.Choice(
         "{{PLACEHOLDER}} tokens. Exits 1 if any are found."
     ),
 )
+@click.option(
+    "--config",
+    "config_path",
+    metavar="PATH",
+    default=None,
+    help=(
+        "Path to a .bootstrap-iac.yaml config file. "
+        "Auto-detected in workspace root if not specified."
+    ),
+)
+@click.option(
+    "--save-config",
+    is_flag=True,
+    default=False,
+    help="Write interview answers to .bootstrap-iac.yaml in the workspace after generation.",
+)
 def main(
     company: Optional[str],
     cloud: Optional[str],
@@ -200,6 +217,8 @@ def main(
     overwrite: bool,
     non_interactive: bool,
     validate_path: Optional[str],
+    config_path: Optional[str],
+    save_config: bool,
 ) -> None:
     """Bootstrap AI agent customisations for a Terraform IaC workspace.
 
@@ -229,6 +248,22 @@ def main(
     # ------------------------------------------------------------------ #
     ws_path = Path(workspace_dir).resolve()
     out_path = Path(output_dir).resolve() if output_dir else ws_path
+
+    # ------------------------------------------------------------------ #
+    # Load config file (defaults that CLI flags override)                   #
+    # ------------------------------------------------------------------ #
+    config_defaults: dict = {}
+    if config_path:
+        cfg_file = Path(config_path).resolve()
+        if not cfg_file.is_file():
+            click.secho(f"  ✗  Config file not found: {cfg_file}", fg="red")
+            sys.exit(1)
+    else:
+        cfg_file = find_config(ws_path)
+
+    if cfg_file:
+        click.echo(f"  Loading config: {cfg_file}")
+        config_defaults = load_config(cfg_file)
 
     # ------------------------------------------------------------------ #
     # Phase 1: Discovery                                                   #
@@ -276,6 +311,9 @@ def main(
     }
 
     overrides: dict = {}
+    # Start with config file values as a base layer
+    overrides.update(config_defaults)
+    # CLI flags override config file values
     if company:
         overrides["COMPANY_NAME"] = company
     if cloud:
@@ -314,6 +352,14 @@ def main(
     )
 
     resolved_target = answers.get("TARGET", "both")
+
+    # ------------------------------------------------------------------ #
+    # --save-config: write answers to .bootstrap-iac.yaml                   #
+    # ------------------------------------------------------------------ #
+    if save_config and not dry_run:
+        config_out = ws_path / ".bootstrap-iac.yaml"
+        write_config(answers, config_out)
+        click.echo(f"  Saved config: {config_out}")
 
     # ------------------------------------------------------------------ #
     # Phase 3: Build full context                                           #

--- a/cli/bootstrap_iac/cli.py
+++ b/cli/bootstrap_iac/cli.py
@@ -201,7 +201,10 @@ _CICD_CHOICES = click.Choice(list(CICD_MAP), case_sensitive=False)
     "--save-config",
     is_flag=True,
     default=False,
-    help="Write interview answers to .bootstrap-iac.yaml in the workspace after generation.",
+    help=(
+        "Write interview answers after generation. Saves back to --config PATH "
+        "when provided; otherwise writes .bootstrap-iac.yaml in the workspace."
+    ),
 )
 def main(
     company: Optional[str],

--- a/cli/bootstrap_iac/cli.py
+++ b/cli/bootstrap_iac/cli.py
@@ -27,9 +27,9 @@ import yaml
 
 from bootstrap_iac import __version__
 from bootstrap_iac.config import (
-    _CICD_MAP,
-    _CLOUD_MAP,
-    _ORCH_MAP,
+    CICD_MAP,
+    CLOUD_MAP,
+    ORCH_MAP,
     find_config,
     load_config,
     write_config,
@@ -91,10 +91,10 @@ def _print_validation_results(issues: dict) -> int:
 # CLI definition
 # ---------------------------------------------------------------------------
 
-_CLOUD_CHOICES = click.Choice(list(_CLOUD_MAP), case_sensitive=False)
+_CLOUD_CHOICES = click.Choice(list(CLOUD_MAP), case_sensitive=False)
 _TARGET_CHOICES = click.Choice(["copilot", "claude", "both"], case_sensitive=False)
-_ORCH_CHOICES = click.Choice(list(_ORCH_MAP), case_sensitive=False)
-_CICD_CHOICES = click.Choice(list(_CICD_MAP), case_sensitive=False)
+_ORCH_CHOICES = click.Choice(list(ORCH_MAP), case_sensitive=False)
+_CICD_CHOICES = click.Choice(list(CICD_MAP), case_sensitive=False)
 
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
@@ -167,7 +167,7 @@ _CICD_CHOICES = click.Choice(list(_CICD_MAP), case_sensitive=False)
     "--overwrite",
     is_flag=True,
     default=False,
-    help="Overwrite existing files (default: skip).",
+    help="Overwrite existing files and config (default: skip).",
 )
 @click.option(
     "--non-interactive",
@@ -308,20 +308,6 @@ def main(
     # ------------------------------------------------------------------ #
     # Normalise CLI flag values to match interview choices                  #
     # ------------------------------------------------------------------ #
-    _cloud_map = {"azure": "Azure", "aws": "AWS", "gcp": "GCP"}
-    _orch_map = {
-        "terragrunt": "Terragrunt",
-        "terramate": "Terramate",
-        "pulumi": "Pulumi",
-        "none": "None",
-    }
-    _cicd_map = {
-        "github-actions": "GitHub Actions",
-        "azure-devops": "Azure DevOps",
-        "gitlab-ci": "GitLab CI",
-        "atlantis": "Atlantis",
-    }
-
     overrides: dict = {}
     # Start with config file values as a base layer
     overrides.update(config_defaults)
@@ -329,15 +315,15 @@ def main(
     if company:
         overrides["COMPANY_NAME"] = company
     if cloud:
-        overrides["CLOUD_PROVIDER"] = _cloud_map.get(cloud.lower(), cloud)
+        overrides["CLOUD_PROVIDER"] = CLOUD_MAP.get(cloud.lower(), cloud)
     if module_prefix:
         overrides["MODULE_PREFIX"] = module_prefix
     if orchestration:
-        overrides["ORCHESTRATION_TOOL"] = _orch_map.get(orchestration.lower(), orchestration)
+        overrides["ORCHESTRATION_TOOL"] = ORCH_MAP.get(orchestration.lower(), orchestration)
     if orchestration_dir:
         overrides["ORCHESTRATION_DIR"] = orchestration_dir
     if ci_cd:
-        overrides["CI_CD_PLATFORM"] = _cicd_map.get(ci_cd.lower(), ci_cd)
+        overrides["CI_CD_PLATFORM"] = CICD_MAP.get(ci_cd.lower(), ci_cd)
     if auth:
         overrides["AUTH_PATTERN"] = auth
     if state_backend:
@@ -389,14 +375,16 @@ def main(
     _print_generated(results, dry_run)
 
     # ------------------------------------------------------------------ #
-    # --save-config: write answers to config file                          #
+    # --save-config: write answers to config file.                         #
+    # The global --overwrite flag also applies to the saved config file.   #
     # ------------------------------------------------------------------ #
     if save_config and not dry_run:
         config_out = cfg_file if cfg_file else (ws_path / ".bootstrap-iac.yaml")
         if config_out.exists() and not overwrite:
             click.secho(
-                f"  ✗  Refusing to overwrite existing config: {config_out}. "
-                "Re-run with --overwrite to replace it.",
+                f"  \u2717  Refusing to overwrite existing config: {config_out}. "
+                "Re-run with --overwrite to replace it; this flag "
+                "applies to both generated files and the saved config.",
                 fg="red",
             )
         else:

--- a/cli/bootstrap_iac/cli.py
+++ b/cli/bootstrap_iac/cli.py
@@ -23,9 +23,10 @@ from pathlib import Path
 from typing import Optional
 
 import click
+import yaml
 
 from bootstrap_iac import __version__
-from bootstrap_iac.config import find_config, load_config, save_config as write_config
+from bootstrap_iac.config import find_config, load_config, write_config
 from bootstrap_iac.discovery import scan_workspace
 from bootstrap_iac.generator import generate_files, get_templates_dir
 from bootstrap_iac.interview import build_context, run_interview
@@ -263,7 +264,11 @@ def main(
 
     if cfg_file:
         click.echo(f"  Loading config: {cfg_file}")
-        config_defaults = load_config(cfg_file)
+        try:
+            config_defaults = load_config(cfg_file)
+        except (yaml.YAMLError, ValueError) as exc:
+            click.secho(f"  ✗  Invalid config file: {exc}", fg="red")
+            sys.exit(1)
 
     # ------------------------------------------------------------------ #
     # Phase 1: Discovery                                                   #
@@ -354,14 +359,6 @@ def main(
     resolved_target = answers.get("TARGET", "both")
 
     # ------------------------------------------------------------------ #
-    # --save-config: write answers to .bootstrap-iac.yaml                   #
-    # ------------------------------------------------------------------ #
-    if save_config and not dry_run:
-        config_out = ws_path / ".bootstrap-iac.yaml"
-        write_config(answers, config_out)
-        click.echo(f"  Saved config: {config_out}")
-
-    # ------------------------------------------------------------------ #
     # Phase 3: Build full context                                           #
     # ------------------------------------------------------------------ #
     context = build_context(answers)
@@ -383,6 +380,14 @@ def main(
     )
 
     _print_generated(results, dry_run)
+
+    # ------------------------------------------------------------------ #
+    # --save-config: write answers to .bootstrap-iac.yaml                   #
+    # ------------------------------------------------------------------ #
+    if save_config and not dry_run:
+        config_out = ws_path / ".bootstrap-iac.yaml"
+        write_config(answers, config_out)
+        click.echo(f"  Saved config: {config_out}")
 
     # ------------------------------------------------------------------ #
     # Summary                                                               #

--- a/cli/bootstrap_iac/config.py
+++ b/cli/bootstrap_iac/config.py
@@ -76,7 +76,20 @@ def load_config(path: Path) -> dict[str, str]:
         upper_key = _KEY_MAP.get(file_key)
         if upper_key is None:
             continue  # ignore unknown keys
-        str_val = str(value)
+
+        if value is None:
+            continue  # treat YAML null as unset
+
+        if isinstance(value, str):
+            str_val = value.strip()
+            if not str_val:
+                continue  # treat empty/whitespace-only strings as unset
+        elif isinstance(value, (bool, int, float)):
+            str_val = str(value)
+        else:
+            raise ValueError(
+                f"Config key '{file_key}' must be a YAML scalar, got {type(value).__name__}"
+            )
 
         # Normalise known enum values
         if upper_key == "CLOUD_PROVIDER":
@@ -85,13 +98,15 @@ def load_config(path: Path) -> dict[str, str]:
             str_val = _ORCH_MAP.get(str_val.lower(), str_val)
         elif upper_key == "CI_CD_PLATFORM":
             str_val = _CICD_MAP.get(str_val.lower(), str_val)
+        elif upper_key == "TARGET":
+            str_val = str_val.lower()
 
         overrides[upper_key] = str_val
 
     return overrides
 
 
-def save_config(answers: dict[str, str], path: Path) -> None:
+def write_config(answers: dict[str, str], path: Path) -> None:
     """Write interview answers to a YAML config file."""
     config: dict[str, str] = {}
     for upper_key, file_key in sorted(_REVERSE_KEY_MAP.items(), key=lambda x: x[1]):
@@ -100,4 +115,4 @@ def save_config(answers: dict[str, str], path: Path) -> None:
             config[file_key] = value
 
     with open(path, "w", encoding="utf-8") as fh:
-        yaml.dump(config, fh, default_flow_style=False, sort_keys=True, allow_unicode=True)
+        yaml.safe_dump(config, fh, default_flow_style=False, sort_keys=True, allow_unicode=True)

--- a/cli/bootstrap_iac/config.py
+++ b/cli/bootstrap_iac/config.py
@@ -27,6 +27,7 @@ _KEY_MAP: dict[str, str] = {
     "state_backend": "STATE_BACKEND",
     "naming": "NAMING_PATTERN",
     "tag_strategy": "TAG_STRATEGY",
+    "standard_variables": "STANDARD_VARIABLES",
     "org": "ORG",
     "target": "TARGET",
 }

--- a/cli/bootstrap_iac/config.py
+++ b/cli/bootstrap_iac/config.py
@@ -35,14 +35,14 @@ _KEY_MAP: dict[str, str] = {
 _REVERSE_KEY_MAP: dict[str, str] = {v: k for k, v in _KEY_MAP.items()}
 
 # Values that need normalisation from CLI lowercase to interview title-case
-_CLOUD_MAP: dict[str, str] = {"azure": "Azure", "aws": "AWS", "gcp": "GCP"}
-_ORCH_MAP: dict[str, str] = {
+CLOUD_MAP: dict[str, str] = {"azure": "Azure", "aws": "AWS", "gcp": "GCP"}
+ORCH_MAP: dict[str, str] = {
     "terragrunt": "Terragrunt",
     "terramate": "Terramate",
     "pulumi": "Pulumi",
     "none": "None",
 }
-_CICD_MAP: dict[str, str] = {
+CICD_MAP: dict[str, str] = {
     "github-actions": "GitHub Actions",
     "azure-devops": "Azure DevOps",
     "gitlab-ci": "GitLab CI",
@@ -59,9 +59,9 @@ def _build_lookup(mapping: dict[str, str]) -> dict[str, str]:
     return lookup
 
 
-_CLOUD_LOOKUP = _build_lookup(_CLOUD_MAP)
-_ORCH_LOOKUP = _build_lookup(_ORCH_MAP)
-_CICD_LOOKUP = _build_lookup(_CICD_MAP)
+_CLOUD_LOOKUP = _build_lookup(CLOUD_MAP)
+_ORCH_LOOKUP = _build_lookup(ORCH_MAP)
+_CICD_LOOKUP = _build_lookup(CICD_MAP)
 
 
 def find_config(workspace: Path) -> Optional[Path]:
@@ -111,7 +111,7 @@ def load_config(path: Path) -> dict[str, str]:
             if normalised is None:
                 raise ValueError(
                     f"Config key 'cloud' has unsupported value '{str_val}'. "
-                    f"Supported: {', '.join(_CLOUD_MAP)}"
+                    f"Supported: {', '.join(CLOUD_MAP)}"
                 )
             str_val = normalised
         elif upper_key == "ORCHESTRATION_TOOL":
@@ -119,7 +119,7 @@ def load_config(path: Path) -> dict[str, str]:
             if normalised is None:
                 raise ValueError(
                     f"Config key 'orchestration' has unsupported value '{str_val}'. "
-                    f"Supported: {', '.join(_ORCH_MAP)}"
+                    f"Supported: {', '.join(ORCH_MAP)}"
                 )
             str_val = normalised
         elif upper_key == "CI_CD_PLATFORM":
@@ -127,7 +127,7 @@ def load_config(path: Path) -> dict[str, str]:
             if normalised is None:
                 raise ValueError(
                     f"Config key 'ci_cd' has unsupported value '{str_val}'. "
-                    f"Supported: {', '.join(_CICD_MAP)}"
+                    f"Supported: {', '.join(CICD_MAP)}"
                 )
             str_val = normalised
         elif upper_key == "TARGET":
@@ -153,4 +153,4 @@ def write_config(answers: dict[str, str], path: Path) -> None:
             config[file_key] = value
 
     with open(path, "w", encoding="utf-8") as fh:
-        yaml.safe_dump(config, fh, default_flow_style=False, sort_keys=True, allow_unicode=True)
+        yaml.safe_dump(config, fh, default_flow_style=False, sort_keys=False, allow_unicode=True)

--- a/cli/bootstrap_iac/config.py
+++ b/cli/bootstrap_iac/config.py
@@ -50,6 +50,20 @@ _CICD_MAP: dict[str, str] = {
 }
 
 
+def _build_lookup(mapping: dict[str, str]) -> dict[str, str]:
+    """Build a case-insensitive lookup accepting both slug keys and display values."""
+    lookup: dict[str, str] = {}
+    for slug, display in mapping.items():
+        lookup[slug.lower()] = display
+        lookup[display.lower()] = display
+    return lookup
+
+
+_CLOUD_LOOKUP = _build_lookup(_CLOUD_MAP)
+_ORCH_LOOKUP = _build_lookup(_ORCH_MAP)
+_CICD_LOOKUP = _build_lookup(_CICD_MAP)
+
+
 def find_config(workspace: Path) -> Optional[Path]:
     """Return the first config file found in *workspace*, or ``None``."""
     for name in CONFIG_FILENAMES:
@@ -91,15 +105,39 @@ def load_config(path: Path) -> dict[str, str]:
                 f"Config key '{file_key}' must be a YAML scalar, got {type(value).__name__}"
             )
 
-        # Normalise known enum values
+        # Normalise and validate known enum values
         if upper_key == "CLOUD_PROVIDER":
-            str_val = _CLOUD_MAP.get(str_val.lower(), str_val)
+            normalised = _CLOUD_LOOKUP.get(str_val.lower())
+            if normalised is None:
+                raise ValueError(
+                    f"Config key 'cloud' has unsupported value '{str_val}'. "
+                    f"Supported: {', '.join(_CLOUD_MAP)}"
+                )
+            str_val = normalised
         elif upper_key == "ORCHESTRATION_TOOL":
-            str_val = _ORCH_MAP.get(str_val.lower(), str_val)
+            normalised = _ORCH_LOOKUP.get(str_val.lower())
+            if normalised is None:
+                raise ValueError(
+                    f"Config key 'orchestration' has unsupported value '{str_val}'. "
+                    f"Supported: {', '.join(_ORCH_MAP)}"
+                )
+            str_val = normalised
         elif upper_key == "CI_CD_PLATFORM":
-            str_val = _CICD_MAP.get(str_val.lower(), str_val)
+            normalised = _CICD_LOOKUP.get(str_val.lower())
+            if normalised is None:
+                raise ValueError(
+                    f"Config key 'ci_cd' has unsupported value '{str_val}'. "
+                    f"Supported: {', '.join(_CICD_MAP)}"
+                )
+            str_val = normalised
         elif upper_key == "TARGET":
-            str_val = str_val.lower()
+            lower = str_val.lower()
+            if lower not in ("copilot", "claude", "both"):
+                raise ValueError(
+                    f"Config key 'target' has unsupported value '{str_val}'. "
+                    f"Supported: copilot, claude, both"
+                )
+            str_val = lower
 
         overrides[upper_key] = str_val
 

--- a/cli/bootstrap_iac/config.py
+++ b/cli/bootstrap_iac/config.py
@@ -1,0 +1,103 @@
+"""Config file support for deterministic re-generation.
+
+Loads and saves ``.bootstrap-iac.yaml`` files so teams can commit their
+interview answers and re-generate consistently.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+# Config file names to auto-detect (in priority order)
+CONFIG_FILENAMES = [".bootstrap-iac.yaml", ".bootstrap-iac.yml"]
+
+# Mapping from config file keys to CLI override keys (UPPER_CASE)
+_KEY_MAP: dict[str, str] = {
+    "company": "COMPANY_NAME",
+    "cloud": "CLOUD_PROVIDER",
+    "module_prefix": "MODULE_PREFIX",
+    "orchestration": "ORCHESTRATION_TOOL",
+    "orchestration_dir": "ORCHESTRATION_DIR",
+    "ci_cd": "CI_CD_PLATFORM",
+    "auth": "AUTH_PATTERN",
+    "state_backend": "STATE_BACKEND",
+    "naming": "NAMING_PATTERN",
+    "tag_strategy": "TAG_STRATEGY",
+    "org": "ORG",
+    "target": "TARGET",
+}
+
+# Reverse mapping for save_config
+_REVERSE_KEY_MAP: dict[str, str] = {v: k for k, v in _KEY_MAP.items()}
+
+# Values that need normalisation from CLI lowercase to interview title-case
+_CLOUD_MAP: dict[str, str] = {"azure": "Azure", "aws": "AWS", "gcp": "GCP"}
+_ORCH_MAP: dict[str, str] = {
+    "terragrunt": "Terragrunt",
+    "terramate": "Terramate",
+    "pulumi": "Pulumi",
+    "none": "None",
+}
+_CICD_MAP: dict[str, str] = {
+    "github-actions": "GitHub Actions",
+    "azure-devops": "Azure DevOps",
+    "gitlab-ci": "GitLab CI",
+    "atlantis": "Atlantis",
+}
+
+
+def find_config(workspace: Path) -> Optional[Path]:
+    """Return the first config file found in *workspace*, or ``None``."""
+    for name in CONFIG_FILENAMES:
+        path = workspace / name
+        if path.is_file():
+            return path
+    return None
+
+
+def load_config(path: Path) -> dict[str, str]:
+    """Load a config file and return normalised overrides (UPPER_CASE keys).
+
+    Values are normalised to match what ``run_interview`` expects
+    (e.g. ``"azure"`` → ``"Azure"``).
+    """
+    with open(path, encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh) or {}
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"Config file must be a YAML mapping, got {type(raw).__name__}")
+
+    overrides: dict[str, str] = {}
+    for file_key, value in raw.items():
+        upper_key = _KEY_MAP.get(file_key)
+        if upper_key is None:
+            continue  # ignore unknown keys
+        str_val = str(value)
+
+        # Normalise known enum values
+        if upper_key == "CLOUD_PROVIDER":
+            str_val = _CLOUD_MAP.get(str_val.lower(), str_val)
+        elif upper_key == "ORCHESTRATION_TOOL":
+            str_val = _ORCH_MAP.get(str_val.lower(), str_val)
+        elif upper_key == "CI_CD_PLATFORM":
+            str_val = _CICD_MAP.get(str_val.lower(), str_val)
+
+        overrides[upper_key] = str_val
+
+    return overrides
+
+
+def save_config(answers: dict[str, str], path: Path) -> None:
+    """Write interview answers to a YAML config file."""
+    config: dict[str, str] = {}
+    for upper_key, file_key in sorted(_REVERSE_KEY_MAP.items(), key=lambda x: x[1]):
+        value = answers.get(upper_key)
+        if value:
+            config[file_key] = value
+
+    with open(path, "w", encoding="utf-8") as fh:
+        yaml.dump(config, fh, default_flow_style=False, sort_keys=True, allow_unicode=True)

--- a/cli/bootstrap_iac/config.py
+++ b/cli/bootstrap_iac/config.py
@@ -31,7 +31,7 @@ _KEY_MAP: dict[str, str] = {
     "target": "TARGET",
 }
 
-# Reverse mapping for save_config
+# Reverse mapping for write_config
 _REVERSE_KEY_MAP: dict[str, str] = {v: k for k, v in _KEY_MAP.items()}
 
 # Values that need normalisation from CLI lowercase to interview title-case

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -12,6 +12,7 @@ license = { text = "MIT" }
 keywords = ["terraform", "iac", "ai", "copilot", "claude", "bootstrap"]
 dependencies = [
     "click>=8.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -114,6 +114,34 @@ def test_load_config_rejects_non_mapping(tmp_path):
         load_config(cfg)
 
 
+def test_load_config_rejects_invalid_cloud(tmp_path):
+    cfg = tmp_path / ".bootstrap-iac.yaml"
+    cfg.write_text("cloud: digitalocean\n")
+    with pytest.raises(ValueError, match="unsupported value 'digitalocean'"):
+        load_config(cfg)
+
+
+def test_load_config_rejects_invalid_orchestration(tmp_path):
+    cfg = tmp_path / ".bootstrap-iac.yaml"
+    cfg.write_text("orchestration: spacelift\n")
+    with pytest.raises(ValueError, match="unsupported value 'spacelift'"):
+        load_config(cfg)
+
+
+def test_load_config_rejects_invalid_cicd(tmp_path):
+    cfg = tmp_path / ".bootstrap-iac.yaml"
+    cfg.write_text("ci_cd: jenkins\n")
+    with pytest.raises(ValueError, match="unsupported value 'jenkins'"):
+        load_config(cfg)
+
+
+def test_load_config_rejects_invalid_target(tmp_path):
+    cfg = tmp_path / ".bootstrap-iac.yaml"
+    cfg.write_text("target: vscode\n")
+    with pytest.raises(ValueError, match="unsupported value 'vscode'"):
+        load_config(cfg)
+
+
 def test_load_config_all_fields(tmp_path):
     cfg = tmp_path / ".bootstrap-iac.yaml"
     cfg.write_text(
@@ -244,14 +272,21 @@ def test_cli_loads_config_file(tmp_path):
         "org: configcorp\n"
         "target: copilot\n"
     )
+    out_dir = tmp_path / "out"
     result = cli_runner.invoke(main, [
         "--workspace", str(ws),
-        "--output-dir", str(tmp_path / "out"),
+        "--output-dir", str(out_dir),
         "--non-interactive",
     ])
     assert result.exit_code == 0
     assert "Loading config" in result.output
-    assert "ConfigCorp" in result.output or (tmp_path / "out" / ".github").exists()
+
+    copilot_instructions = out_dir / ".github" / "copilot-instructions.md"
+    assert copilot_instructions.is_file()
+
+    rendered = copilot_instructions.read_text()
+    assert "ConfigCorp" in rendered
+    assert "Azure" in rendered
 
 
 def test_cli_flag_overrides_config(tmp_path):

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from bootstrap_iac.config import find_config, load_config, save_config
+from bootstrap_iac.config import find_config, load_config, write_config
 
 
 # ---------------------------------------------------------------------------
@@ -146,11 +146,11 @@ def test_load_config_all_fields(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# save_config
+# write_config
 # ---------------------------------------------------------------------------
 
 
-def test_save_config_roundtrip(tmp_path):
+def test_write_config_roundtrip(tmp_path):
     answers = {
         "COMPANY_NAME": "Acme Corp",
         "CLOUD_PROVIDER": "Azure",
@@ -160,13 +160,13 @@ def test_save_config_roundtrip(tmp_path):
         "CI_CD_PLATFORM": "GitHub Actions",
         "AUTH_PATTERN": "OIDC",
         "STATE_BACKEND": "azurerm",
-        "NAMING_PATTERN": "{prefix}-{resource}-{suffix}",
+        "NAMING_PATTERN": "{prefix}-{resource_abbreviation}-{suffix}",
         "TAG_STRATEGY": "merge(var.env_default_tags, var.tags)",
         "ORG": "acme",
         "TARGET": "both",
     }
     out = tmp_path / ".bootstrap-iac.yaml"
-    save_config(answers, out)
+    write_config(answers, out)
 
     assert out.exists()
     content = yaml.safe_load(out.read_text())
@@ -178,7 +178,7 @@ def test_save_config_roundtrip(tmp_path):
     assert content["target"] == "both"
 
 
-def test_save_config_skips_empty_values(tmp_path):
+def test_write_config_skips_empty_values(tmp_path):
     answers = {
         "COMPANY_NAME": "Acme",
         "CLOUD_PROVIDER": "",
@@ -186,7 +186,7 @@ def test_save_config_skips_empty_values(tmp_path):
         "ORG": "acme",
     }
     out = tmp_path / ".bootstrap-iac.yaml"
-    save_config(answers, out)
+    write_config(answers, out)
 
     content = yaml.safe_load(out.read_text())
     assert "company" in content
@@ -196,7 +196,7 @@ def test_save_config_skips_empty_values(tmp_path):
 
 
 def test_save_then_load_roundtrip(tmp_path):
-    """save_config output can be loaded back via load_config."""
+    """write_config output can be loaded back via load_config."""
     answers = {
         "COMPANY_NAME": "RoundTrip Inc",
         "CLOUD_PROVIDER": "GCP",
@@ -207,7 +207,7 @@ def test_save_then_load_roundtrip(tmp_path):
         "TARGET": "claude",
     }
     out = tmp_path / ".bootstrap-iac.yaml"
-    save_config(answers, out)
+    write_config(answers, out)
 
     loaded = load_config(out)
     assert loaded["COMPANY_NAME"] == "RoundTrip Inc"
@@ -260,15 +260,22 @@ def test_cli_flag_overrides_config(tmp_path):
     cfg = ws / ".bootstrap-iac.yaml"
     cfg.write_text("company: ConfigCorp\ncloud: azure\ntarget: both\n")
 
+    out_dir = tmp_path / "out"
     result = cli_runner.invoke(main, [
         "--workspace", str(ws),
-        "--output-dir", str(tmp_path / "out"),
+        "--output-dir", str(out_dir),
         "--company", "FlagCorp",
         "--target", "copilot",
         "--non-interactive",
     ])
     assert result.exit_code == 0
-    # FlagCorp should be used, not ConfigCorp
+    # --target copilot overrides config target=both → only .github/, no CLAUDE.md
+    assert (out_dir / ".github").is_dir()
+    assert not (out_dir / "CLAUDE.md").exists()
+    # --company FlagCorp overrides config company=ConfigCorp
+    copilot_instructions = (out_dir / ".github" / "copilot-instructions.md").read_text()
+    assert "FlagCorp" in copilot_instructions
+    assert "ConfigCorp" not in copilot_instructions
 
 
 def test_cli_explicit_config_path(tmp_path):

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -7,6 +7,9 @@ from pathlib import Path
 import pytest
 import yaml
 
+from click.testing import CliRunner
+
+from bootstrap_iac.cli import main
 from bootstrap_iac.config import find_config, load_config, write_config
 
 
@@ -248,9 +251,6 @@ def test_save_then_load_roundtrip(tmp_path):
 # CLI integration (config file loading via CliRunner)
 # ---------------------------------------------------------------------------
 
-from click.testing import CliRunner
-from bootstrap_iac.cli import main
-
 cli_runner = CliRunner()
 
 
@@ -383,3 +383,69 @@ def test_cli_save_config_not_written_on_dry_run(tmp_path):
     ])
     assert result.exit_code == 0
     assert not (ws / ".bootstrap-iac.yaml").exists()
+
+
+def test_cli_save_config_refuses_overwrite(tmp_path):
+    """--save-config without --overwrite refuses to overwrite existing config."""
+    ws = _make_workspace(tmp_path)
+    cfg = ws / ".bootstrap-iac.yaml"
+    cfg.write_text("company: Original\n")
+    result = cli_runner.invoke(main, [
+        "--workspace", str(ws),
+        "--company", "NewCorp",
+        "--cloud", "azure",
+        "--orchestration", "none",
+        "--ci-cd", "github-actions",
+        "--target", "copilot",
+        "--non-interactive",
+        "--save-config",
+    ])
+    assert result.exit_code == 0
+    assert "Refusing to overwrite" in result.output
+    # Original config should be unchanged
+    assert yaml.safe_load(cfg.read_text())["company"] == "Original"
+
+
+def test_cli_save_config_overwrites_with_flag(tmp_path):
+    """--save-config with --overwrite replaces existing config."""
+    ws = _make_workspace(tmp_path)
+    cfg = ws / ".bootstrap-iac.yaml"
+    cfg.write_text("company: Original\n")
+    result = cli_runner.invoke(main, [
+        "--workspace", str(ws),
+        "--company", "NewCorp",
+        "--cloud", "azure",
+        "--orchestration", "none",
+        "--ci-cd", "github-actions",
+        "--target", "copilot",
+        "--non-interactive",
+        "--save-config",
+        "--overwrite",
+    ])
+    assert result.exit_code == 0
+    assert "Saved config" in result.output
+    assert yaml.safe_load(cfg.read_text())["company"] == "NewCorp"
+
+
+def test_cli_save_config_writes_to_detected_yml(tmp_path):
+    """--save-config writes back to detected .yml file, not creating a new .yaml."""
+    ws = _make_workspace(tmp_path)
+    cfg = ws / ".bootstrap-iac.yml"
+    cfg.write_text("company: Original\n")
+    result = cli_runner.invoke(main, [
+        "--workspace", str(ws),
+        "--company", "YmlCorp",
+        "--cloud", "aws",
+        "--orchestration", "none",
+        "--ci-cd", "github-actions",
+        "--target", "copilot",
+        "--non-interactive",
+        "--save-config",
+        "--overwrite",
+    ])
+    assert result.exit_code == 0
+    assert "Saved config" in result.output
+    # Should have written to .yml, not created .yaml
+    assert cfg.exists()
+    assert not (ws / ".bootstrap-iac.yaml").exists()
+    assert yaml.safe_load(cfg.read_text())["company"] == "YmlCorp"

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -1,0 +1,343 @@
+"""Tests for config file support (.bootstrap-iac.yaml)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from bootstrap_iac.config import find_config, load_config, save_config
+
+
+# ---------------------------------------------------------------------------
+# find_config
+# ---------------------------------------------------------------------------
+
+
+def test_find_config_yaml(tmp_path):
+    cfg = tmp_path / ".bootstrap-iac.yaml"
+    cfg.write_text("company: Acme\n")
+    assert find_config(tmp_path) == cfg
+
+
+def test_find_config_yml(tmp_path):
+    cfg = tmp_path / ".bootstrap-iac.yml"
+    cfg.write_text("company: Acme\n")
+    assert find_config(tmp_path) == cfg
+
+
+def test_find_config_prefers_yaml_over_yml(tmp_path):
+    (tmp_path / ".bootstrap-iac.yaml").write_text("company: Yaml\n")
+    (tmp_path / ".bootstrap-iac.yml").write_text("company: Yml\n")
+    assert find_config(tmp_path).name == ".bootstrap-iac.yaml"
+
+
+def test_find_config_returns_none(tmp_path):
+    assert find_config(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# load_config
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_basic(tmp_path):
+    cfg = tmp_path / ".bootstrap-iac.yaml"
+    cfg.write_text(
+        "company: Acme Corp\n"
+        "cloud: azure\n"
+        "module_prefix: tf-module\n"
+        "orchestration: terragrunt\n"
+        "ci_cd: github-actions\n"
+        "org: acme\n"
+        "target: both\n"
+    )
+    result = load_config(cfg)
+    assert result["COMPANY_NAME"] == "Acme Corp"
+    assert result["CLOUD_PROVIDER"] == "Azure"
+    assert result["MODULE_PREFIX"] == "tf-module"
+    assert result["ORCHESTRATION_TOOL"] == "Terragrunt"
+    assert result["CI_CD_PLATFORM"] == "GitHub Actions"
+    assert result["ORG"] == "acme"
+    assert result["TARGET"] == "both"
+
+
+def test_load_config_normalises_cloud_cases(tmp_path):
+    for raw, expected in [("azure", "Azure"), ("AWS", "AWS"), ("gcp", "GCP")]:
+        cfg = tmp_path / ".bootstrap-iac.yaml"
+        cfg.write_text(f"cloud: {raw}\n")
+        assert load_config(cfg)["CLOUD_PROVIDER"] == expected
+
+
+def test_load_config_normalises_orchestration(tmp_path):
+    for raw, expected in [
+        ("terragrunt", "Terragrunt"),
+        ("Terramate", "Terramate"),
+        ("PULUMI", "Pulumi"),
+        ("none", "None"),
+    ]:
+        cfg = tmp_path / ".bootstrap-iac.yaml"
+        cfg.write_text(f"orchestration: {raw}\n")
+        assert load_config(cfg)["ORCHESTRATION_TOOL"] == expected
+
+
+def test_load_config_normalises_cicd(tmp_path):
+    for raw, expected in [
+        ("github-actions", "GitHub Actions"),
+        ("azure-devops", "Azure DevOps"),
+        ("gitlab-ci", "GitLab CI"),
+        ("atlantis", "Atlantis"),
+    ]:
+        cfg = tmp_path / ".bootstrap-iac.yaml"
+        cfg.write_text(f"ci_cd: {raw}\n")
+        assert load_config(cfg)["CI_CD_PLATFORM"] == expected
+
+
+def test_load_config_ignores_unknown_keys(tmp_path):
+    cfg = tmp_path / ".bootstrap-iac.yaml"
+    cfg.write_text("company: Acme\nunknown_key: ignored\n")
+    result = load_config(cfg)
+    assert result == {"COMPANY_NAME": "Acme"}
+
+
+def test_load_config_empty_file(tmp_path):
+    cfg = tmp_path / ".bootstrap-iac.yaml"
+    cfg.write_text("")
+    assert load_config(cfg) == {}
+
+
+def test_load_config_rejects_non_mapping(tmp_path):
+    cfg = tmp_path / ".bootstrap-iac.yaml"
+    cfg.write_text("- item1\n- item2\n")
+    with pytest.raises(ValueError, match="YAML mapping"):
+        load_config(cfg)
+
+
+def test_load_config_all_fields(tmp_path):
+    cfg = tmp_path / ".bootstrap-iac.yaml"
+    cfg.write_text(
+        "company: Test Corp\n"
+        "cloud: aws\n"
+        "module_prefix: terraform-aws\n"
+        "orchestration: none\n"
+        "orchestration_dir: infra\n"
+        "ci_cd: gitlab-ci\n"
+        "auth: OIDC\n"
+        "state_backend: S3\n"
+        "naming: prefix-type-suffix\n"
+        "tag_strategy: merge tags\n"
+        "org: testorg\n"
+        "target: copilot\n"
+    )
+    result = load_config(cfg)
+    assert result["COMPANY_NAME"] == "Test Corp"
+    assert result["CLOUD_PROVIDER"] == "AWS"
+    assert result["MODULE_PREFIX"] == "terraform-aws"
+    assert result["ORCHESTRATION_TOOL"] == "None"
+    assert result["ORCHESTRATION_DIR"] == "infra"
+    assert result["CI_CD_PLATFORM"] == "GitLab CI"
+    assert result["AUTH_PATTERN"] == "OIDC"
+    assert result["STATE_BACKEND"] == "S3"
+    assert result["NAMING_PATTERN"] == "prefix-type-suffix"
+    assert result["TAG_STRATEGY"] == "merge tags"
+    assert result["ORG"] == "testorg"
+    assert result["TARGET"] == "copilot"
+
+
+# ---------------------------------------------------------------------------
+# save_config
+# ---------------------------------------------------------------------------
+
+
+def test_save_config_roundtrip(tmp_path):
+    answers = {
+        "COMPANY_NAME": "Acme Corp",
+        "CLOUD_PROVIDER": "Azure",
+        "MODULE_PREFIX": "tf-module",
+        "ORCHESTRATION_TOOL": "Terragrunt",
+        "ORCHESTRATION_DIR": "infrastructure-config",
+        "CI_CD_PLATFORM": "GitHub Actions",
+        "AUTH_PATTERN": "OIDC",
+        "STATE_BACKEND": "azurerm",
+        "NAMING_PATTERN": "{prefix}-{resource}-{suffix}",
+        "TAG_STRATEGY": "merge(var.env_default_tags, var.tags)",
+        "ORG": "acme",
+        "TARGET": "both",
+    }
+    out = tmp_path / ".bootstrap-iac.yaml"
+    save_config(answers, out)
+
+    assert out.exists()
+    content = yaml.safe_load(out.read_text())
+    assert content["company"] == "Acme Corp"
+    assert content["cloud"] == "Azure"
+    assert content["orchestration"] == "Terragrunt"
+    assert content["ci_cd"] == "GitHub Actions"
+    assert content["org"] == "acme"
+    assert content["target"] == "both"
+
+
+def test_save_config_skips_empty_values(tmp_path):
+    answers = {
+        "COMPANY_NAME": "Acme",
+        "CLOUD_PROVIDER": "",
+        "MODULE_PREFIX": "",
+        "ORG": "acme",
+    }
+    out = tmp_path / ".bootstrap-iac.yaml"
+    save_config(answers, out)
+
+    content = yaml.safe_load(out.read_text())
+    assert "company" in content
+    assert "org" in content
+    assert "cloud" not in content
+    assert "module_prefix" not in content
+
+
+def test_save_then_load_roundtrip(tmp_path):
+    """save_config output can be loaded back via load_config."""
+    answers = {
+        "COMPANY_NAME": "RoundTrip Inc",
+        "CLOUD_PROVIDER": "GCP",
+        "MODULE_PREFIX": "tf-gcp",
+        "ORCHESTRATION_TOOL": "None",
+        "CI_CD_PLATFORM": "GitHub Actions",
+        "ORG": "roundtrip",
+        "TARGET": "claude",
+    }
+    out = tmp_path / ".bootstrap-iac.yaml"
+    save_config(answers, out)
+
+    loaded = load_config(out)
+    assert loaded["COMPANY_NAME"] == "RoundTrip Inc"
+    assert loaded["CLOUD_PROVIDER"] == "GCP"
+    assert loaded["ORCHESTRATION_TOOL"] == "None"
+    assert loaded["TARGET"] == "claude"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration (config file loading via CliRunner)
+# ---------------------------------------------------------------------------
+
+from click.testing import CliRunner
+from bootstrap_iac.cli import main
+
+cli_runner = CliRunner()
+
+
+def _make_workspace(tmp_path: Path) -> Path:
+    (tmp_path / "main.tf").write_text('provider "azurerm" {\n  features {}\n}\n')
+    return tmp_path
+
+
+def test_cli_loads_config_file(tmp_path):
+    """Config file values are used as defaults in non-interactive mode."""
+    ws = _make_workspace(tmp_path)
+    cfg = ws / ".bootstrap-iac.yaml"
+    cfg.write_text(
+        "company: ConfigCorp\n"
+        "cloud: azure\n"
+        "module_prefix: tf-mod\n"
+        "orchestration: none\n"
+        "ci_cd: github-actions\n"
+        "org: configcorp\n"
+        "target: copilot\n"
+    )
+    result = cli_runner.invoke(main, [
+        "--workspace", str(ws),
+        "--output-dir", str(tmp_path / "out"),
+        "--non-interactive",
+    ])
+    assert result.exit_code == 0
+    assert "Loading config" in result.output
+    assert "ConfigCorp" in result.output or (tmp_path / "out" / ".github").exists()
+
+
+def test_cli_flag_overrides_config(tmp_path):
+    """CLI flags take precedence over config file values."""
+    ws = _make_workspace(tmp_path)
+    cfg = ws / ".bootstrap-iac.yaml"
+    cfg.write_text("company: ConfigCorp\ncloud: azure\ntarget: both\n")
+
+    result = cli_runner.invoke(main, [
+        "--workspace", str(ws),
+        "--output-dir", str(tmp_path / "out"),
+        "--company", "FlagCorp",
+        "--target", "copilot",
+        "--non-interactive",
+    ])
+    assert result.exit_code == 0
+    # FlagCorp should be used, not ConfigCorp
+
+
+def test_cli_explicit_config_path(tmp_path):
+    """--config flag loads a specific config file."""
+    ws = _make_workspace(tmp_path)
+    cfg = tmp_path / "custom-config.yaml"
+    cfg.write_text(
+        "company: CustomCfg\n"
+        "cloud: aws\n"
+        "orchestration: none\n"
+        "ci_cd: github-actions\n"
+        "target: claude\n"
+    )
+    result = cli_runner.invoke(main, [
+        "--workspace", str(ws),
+        "--output-dir", str(tmp_path / "out"),
+        "--config", str(cfg),
+        "--non-interactive",
+    ])
+    assert result.exit_code == 0
+    assert "Loading config" in result.output
+
+
+def test_cli_config_not_found(tmp_path):
+    """--config with a nonexistent path exits with error."""
+    ws = _make_workspace(tmp_path)
+    result = cli_runner.invoke(main, [
+        "--workspace", str(ws),
+        "--config", str(tmp_path / "nonexistent.yaml"),
+        "--non-interactive",
+    ])
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+def test_cli_save_config(tmp_path):
+    """--save-config writes a .bootstrap-iac.yaml to the workspace."""
+    ws = _make_workspace(tmp_path)
+    result = cli_runner.invoke(main, [
+        "--workspace", str(ws),
+        "--company", "SaveCorp",
+        "--cloud", "azure",
+        "--orchestration", "none",
+        "--ci-cd", "github-actions",
+        "--target", "copilot",
+        "--non-interactive",
+        "--save-config",
+    ])
+    assert result.exit_code == 0
+    cfg_out = ws / ".bootstrap-iac.yaml"
+    assert cfg_out.exists()
+    content = yaml.safe_load(cfg_out.read_text())
+    assert content["company"] == "SaveCorp"
+    assert content["cloud"] == "Azure"
+
+
+def test_cli_save_config_not_written_on_dry_run(tmp_path):
+    """--save-config with --dry-run should not write the config file."""
+    ws = _make_workspace(tmp_path)
+    result = cli_runner.invoke(main, [
+        "--workspace", str(ws),
+        "--company", "DryRunCorp",
+        "--cloud", "azure",
+        "--orchestration", "none",
+        "--ci-cd", "github-actions",
+        "--target", "copilot",
+        "--non-interactive",
+        "--save-config",
+        "--dry-run",
+    ])
+    assert result.exit_code == 0
+    assert not (ws / ".bootstrap-iac.yaml").exists()

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -158,6 +158,7 @@ def test_load_config_all_fields(tmp_path):
         "state_backend: S3\n"
         "naming: prefix-type-suffix\n"
         "tag_strategy: merge tags\n"
+        "standard_variables: prefix, location, tags\n"
         "org: testorg\n"
         "target: copilot\n"
     )
@@ -172,6 +173,7 @@ def test_load_config_all_fields(tmp_path):
     assert result["STATE_BACKEND"] == "S3"
     assert result["NAMING_PATTERN"] == "prefix-type-suffix"
     assert result["TAG_STRATEGY"] == "merge tags"
+    assert result["STANDARD_VARIABLES"] == "prefix, location, tags"
     assert result["ORG"] == "testorg"
     assert result["TARGET"] == "copilot"
 
@@ -193,6 +195,7 @@ def test_write_config_roundtrip(tmp_path):
         "STATE_BACKEND": "azurerm",
         "NAMING_PATTERN": "{prefix}-{resource_abbreviation}-{suffix}",
         "TAG_STRATEGY": "merge(var.env_default_tags, var.tags)",
+        "STANDARD_VARIABLES": "- prefix\n- location\n- tags",
         "ORG": "acme",
         "TARGET": "both",
     }


### PR DESCRIPTION
## Summary

Closes #52 — adds config file support for deterministic re-generation.

### Changes

1. **New module `cli/bootstrap_iac/config.py`**:
   - `find_config(workspace)` — auto-detects `.bootstrap-iac.yaml` / `.bootstrap-iac.yml` in workspace root
   - `load_config(path)` — loads YAML config, normalises values (e.g. `azure` → `Azure`, `github-actions` → `GitHub Actions`)
   - `save_config(answers, path)` — writes interview answers back to YAML

2. **CLI integration (`cli.py`)**:
   - `--config PATH` flag to specify a config file explicitly
   - `--save-config` flag to write answers after generation
   - Auto-detection of config files in workspace root
   - Config values serve as defaults; CLI flags override them
   - Config file not written on `--dry-run`

3. **Added `pyyaml>=6.0` dependency** (`pyproject.toml`)

4. **21 new tests** (`cli/tests/test_config.py`):
   - `find_config`: auto-detection, priority (.yaml over .yml), missing file
   - `load_config`: basic load, normalisation (cloud/orchestration/cicd), unknown keys, empty file, non-mapping rejection, all fields
   - `save_config`: roundtrip, skips empty values, save-then-load roundtrip
   - CLI integration: config auto-loading, flag override, explicit `--config` path, missing config error, `--save-config`, dry-run skips save

5. **Updated `cli/README.md`**: new Config File section, added `--config` and `--save-config` to options table

### Config File Format

```yaml
company: Acme Corp
cloud: azure
module_prefix: tf-module
orchestration: terragrunt
ci_cd: github-actions
org: acme
target: both
```

### Precedence Order

CLI flags > config file > discovery defaults > interactive prompts

### Test Results

132 tests passing (111 existing + 21 new)
